### PR TITLE
Start and Stop Commands

### DIFF
--- a/little-cli/src/main.rs
+++ b/little-cli/src/main.rs
@@ -4,7 +4,6 @@ use little::CommandRequest;
 use std::process::Command as ProcessCommand;
 use tokio::time::sleep;
 use std::time::Duration;
-use tonic::transport::Error as TonicError;
 use std::error::Error;
 use std::fmt;
 

--- a/little-cli/src/main.rs
+++ b/little-cli/src/main.rs
@@ -1,10 +1,35 @@
 use clap::{Parser};
 use little::little_service_client::LittleServiceClient;
 use little::CommandRequest;
+use std::process::Command as ProcessCommand;
+use tokio::time::sleep;
+use std::time::Duration;
+use tonic::transport::Error as TonicError;
+use std::error::Error;
+use std::fmt;
 
 pub mod little {
     tonic::include_proto!("little");
 }
+
+#[derive(Debug)]
+enum CliError {
+    DaemonStart(String),
+    Connection(String),
+    Command(String),
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CliError::DaemonStart(msg) => write!(f, "Failed to start daemon: {}", msg),
+            CliError::Connection(msg) => write!(f, "Connection error: {}", msg),
+            CliError::Command(msg) => write!(f, "Command error: {}", msg),
+        }
+    }
+}
+
+impl Error for CliError {}
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -13,19 +38,54 @@ struct Cli {
     command: littled::commands::Command,
 }
 
+async fn is_daemon_running() -> bool {
+    match LittleServiceClient::connect("http://[::1]:50051").await {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+async fn start_daemon() -> Result<(), CliError> {
+    println!("Starting littled daemon...");
+    let mut child = ProcessCommand::new("./target/debug/littled")
+        .spawn()
+        .map_err(|e| CliError::DaemonStart(e.to_string()))?;
+
+    // Give the daemon a moment to start
+    sleep(Duration::from_secs(2)).await;
+    
+    // Check if process is still running
+    match child.try_wait()
+        .map_err(|e| CliError::DaemonStart(e.to_string()))? {
+        Some(status) => {
+            Err(CliError::DaemonStart(format!("Process exited with status {}", status)))
+        },
+        None => Ok(())
+    }
+}
+
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), Box<dyn Error>> {
     let cli = Cli::parse();
 
-    let mut client = LittleServiceClient::connect("http://[::1]:50051").await?;
+    // If this is a start command and daemon isn't running, start it
+    if matches!(cli.command, littled::commands::Command::Start { .. }) && !is_daemon_running().await {
+        start_daemon().await?;
+    }
+
+    // Try to connect to the daemon
+    let mut client = LittleServiceClient::connect("http://[::1]:50051").await
+        .map_err(|e| CliError::Connection(e.to_string()))?;
 
     let request = tonic::Request::new(CommandRequest {
-        command: serde_json::to_string(&cli.command)?,
+        command: serde_json::to_string(&cli.command)
+            .map_err(|e| CliError::Command(e.to_string()))?,
         arguments: std::collections::HashMap::new(),
     });
 
-    let response = client.execute_command(request).await?;
-
+    let response = client.execute_command(request).await
+        .map_err(|e| CliError::Command(e.to_string()))?;
+    
     println!("RESPONSE={:?}", response);
 
     Ok(())

--- a/littled/src/main.rs
+++ b/littled/src/main.rs
@@ -33,6 +33,8 @@ struct MyLittleService {
     state: Arc<Mutex<String>>,
     alias: String,
     node_id: String,
+    node: Arc<Mutex<Option<ldk_node::Node>>>,
+    shutdown_signal: Arc<tokio::sync::broadcast::Sender<()>>,
 }
 
 #[tonic::async_trait]
@@ -52,9 +54,25 @@ impl LittleService for MyLittleService {
                 status: "started".to_string(),
                 message: format!("Started with name: {:?}", name),
             },
-            Command::Stop => CommandResponse {
-                status: "stopped".to_string(),
-                message: "Stopped".to_string(),
+            Command::Stop => {
+                // Gracefully stop the LDK node
+                if let Some(node) = self.node.lock().await.take() {
+                    println!("Stopping LDK node...");
+                    // Spawn a blocking task to stop the node
+                    tokio::task::spawn_blocking(move || {
+                        if let Err(e) = node.stop() {
+                            eprintln!("Error stopping node: {}", e);
+                        }
+                    });
+                }
+                
+                // Signal shutdown to the servers
+                let _ = self.shutdown_signal.send(());
+                
+                CommandResponse {
+                    status: "stopped".to_string(),
+                    message: "Node shutdown initiated".to_string(),
+                }
             },
             Command::GetInfo => CommandResponse {
                 status: "info".to_string(),
@@ -85,10 +103,26 @@ async fn handle_http_command(
                 "message": format!("Started with name: {}", name)
             })
         },
-        "stop" => serde_json::json!({
-            "status": "stopped",
-            "message": "Stopped"
-        }),
+        "stop" => {
+            // Gracefully stop the LDK node
+            if let Some(node) = service.node.lock().await.take() {
+                println!("Stopping LDK node...");
+                // Spawn a blocking task to stop the node
+                tokio::task::spawn_blocking(move || {
+                    if let Err(e) = node.stop() {
+                        eprintln!("Error stopping node: {}", e);
+                    }
+                });
+            }
+            
+            // Signal shutdown to the servers
+            let _ = service.shutdown_signal.send(());
+            
+            serde_json::json!({
+                "status": "stopped",
+                "message": "Node shutdown initiated"
+            })
+        },
         "getinfo" => serde_json::json!({
             "status": "info",
             "message": {
@@ -120,39 +154,63 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let (node, node_id) = make_node(&alias, 9735);
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel(1);
 
     let service = MyLittleService {
         state: Arc::new(Mutex::new(String::new())),
         alias,
         node_id,
+        node: Arc::new(Mutex::new(Some(node))),
+        shutdown_signal: Arc::new(shutdown_tx),
     };
-    let service_clone = service.clone();
-
+    
     let grpc_addr = "[::1]:50051".parse()?;
-    let grpc_service = LittleServiceServer::new(service);
-    let grpc_server = Server::builder().add_service(grpc_service).serve(grpc_addr);
+    let grpc_service = LittleServiceServer::new(service.clone());
+    
+    // Create a new receiver for gRPC server
+    let mut grpc_shutdown_rx = service.shutdown_signal.subscribe();
+    let grpc_server = Server::builder().add_service(grpc_service).serve_with_shutdown(
+        grpc_addr,
+        async move {
+            grpc_shutdown_rx.recv().await.ok();
+            println!("Shutting down gRPC server...");
+        },
+    );
 
     println!("gRPC server listening on {}", grpc_addr);
 
     let http_addr = ([127, 0, 0, 1], 3030);
+    
+    // Create a new clone for the HTTP routes
+    let http_service = service.clone();
     let http_routes = warp::post()
         .and(warp::path("little"))
         .and(warp::path("api"))
         .and(warp::path("v1"))
         .and(warp::path("command"))
         .and(warp::body::json())
-        .and(warp::any().map(move || service_clone.clone()))
+        .and(warp::any().map(move || http_service.clone()))
         .and_then(handle_http_command);
 
-    let http_server = warp::serve(http_routes).run(http_addr);
+    // Create a new receiver for HTTP server
+    let mut http_shutdown_rx = service.shutdown_signal.subscribe();
+    let (_, http_server) = warp::serve(http_routes)
+        .bind_with_graceful_shutdown(
+            http_addr,
+            async move {
+                http_shutdown_rx.recv().await.ok();
+                println!("Shutting down HTTP server...");
+            },
+        );
 
     println!("HTTP server listening on http://{:?}", http_addr);
 
     tokio::join!(
-        Box::pin(grpc_server) as Pin<Box<dyn Future<Output = _> + Send>>,
-        Box::pin(http_server) as Pin<Box<dyn Future<Output = _> + Send>>,
+        grpc_server,
+        http_server,
     );
 
+    println!("Servers shut down successfully");
     Ok(())
 }
 


### PR DESCRIPTION
Ad `start` and `stop` to the CLI and HTTP API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error messaging and status checks to better inform users when starting services.
	- Improved lifecycle management, enabling smoother startup and graceful shutdown of service operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->