### PR TITLE
Fix gRPC server shutdown

### DIFF
--- a/littled/src/main.rs
+++ b/littled/src/main.rs
@@ -953,9 +953,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Start gRPC server
     let grpc_addr = format!("[::1]:{}", config.grpc_port).parse()?;
     let grpc_service = LittleServiceServer::new(service.clone());
+    let grpc_shutdown_signal = shutdown_signal.clone();
     let grpc_server = Server::builder()
         .add_service(grpc_service)
-        .serve(grpc_addr);
+        .serve_with_shutdown(grpc_addr, async move {
+            let mut shutdown_receiver = grpc_shutdown_signal.subscribe();
+            shutdown_receiver.recv().await.ok();
+            println!("Shutting down gRPC server...");
+        });
 
     println!("gRPC server listening on {}", grpc_addr);
 


### PR DESCRIPTION
## Summary
- shut down gRPC server when daemon receives stop signal

## Testing
- `cargo build --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684746e877608331a4a4beb685389509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The gRPC server now supports graceful shutdown, allowing it to terminate cleanly when a shutdown signal is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->